### PR TITLE
Add custom cash out tax option

### DIFF
--- a/src/app/create/form/AddStageDialog.tsx
+++ b/src/app/create/form/AddStageDialog.tsx
@@ -16,8 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  defaultStageData } from "../constants";
+import { defaultStageData } from "../constants";
 import { Field, FieldGroup } from "./Fields";
 import { Input } from "@/components/ui/input";
 import {
@@ -52,7 +51,7 @@ function NotesSection({
       >
         <div className="font-sm">{title}</div>
         <span
-          className={`transform transition-transform font-sm ${
+          className={`font-sm transform transition-transform ${
             isOpen ? "rotate-90" : "rotate-0"
           }`}
         >
@@ -62,7 +61,7 @@ function NotesSection({
 
       {/* Dropdown Content */}
       {isOpen && (
-        <div className="mt-2 pl-4 text-gray-600 text-md">{children}</div>
+        <div className="text-md mt-2 pl-4 text-gray-600">{children}</div>
       )}
     </div>
   );
@@ -82,7 +81,9 @@ export function AddStageDialog({
   const { values: formikValues } = useFormikContext<RevnetFormData>();
 
   const [open, setOpen] = useState(false);
-  const [initialIssuance, setInitialIssuance] = useState(initialValues?.initialIssuance || "10000");
+  const [initialIssuance, setInitialIssuance] = useState(
+    initialValues?.initialIssuance || "10000",
+  );
   const nativeTokenSymbol = useNativeTokenSymbol();
 
   const revnetTokenSymbol =
@@ -90,16 +91,18 @@ export function AddStageDialog({
       ? `$${formikValues.tokenSymbol}`
       : "tokens";
 
-    const [cashOutTax, setCashOutTax] = useState(initialValues?.priceFloorTaxIntensity || 20); // Default to 0.2
+  const [cashOutTax, setCashOutTax] = useState<number>(
+    Number(initialValues?.priceFloorTaxIntensity) || 20,
+  ); // Default to 20%
 
-    // Discrete values matching your radio options
-    const steps = [0, 20, 40, 60, 80];
+  // Discrete values matching your radio options
+  const steps = [0, 20, 40, 60, 80];
 
-    // Calculate example yield based on selected tax rate
-    const calculateYield = (taxRate: number) => {
-      console.log({taxRate});
-      return (Number(((1-(taxRate/100))+((taxRate/100)/10))) * 10).toFixed(1);
-    };
+  // Calculate example yield based on selected tax rate
+  const calculateYield = (taxRate: number) => {
+    console.log({ taxRate });
+    return (Number(1 - taxRate / 100 + taxRate / 100 / 10) * 10).toFixed(1);
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -119,15 +122,15 @@ export function AddStageDialog({
             {({ values }) => (
               <Form>
                 <div className="pb-6">
-
                   <div>
-                    <div className="block text-md font-semibold leading-6">
+                    <div className="text-md block font-semibold leading-6">
                       1. Issuance
                     </div>
-                    <p className="text-md text-zinc-500 mt-3">
-                      How many {revnetTokenSymbol} to issue when receiving 1 {nativeTokenSymbol}.
+                    <p className="text-md mt-3 text-zinc-500">
+                      How many {revnetTokenSymbol} to issue when receiving 1{" "}
+                      {nativeTokenSymbol}.
                     </p>
-                    <div className="flex flex-wrap md:flex-nowrap gap-4 sm:gap-2 items-center text-md text-zinc-600 mt-2">
+                    <div className="text-md mt-2 flex flex-wrap items-center gap-4 text-zinc-600 sm:gap-2 md:flex-nowrap">
                       <div className="w-full sm:w-[200px] lg:w-[200px] xl:w-[200px]">
                         <FieldGroup
                           id="initialIssuance"
@@ -143,7 +146,7 @@ export function AddStageDialog({
                           suffix={`${revnetTokenSymbol} / ${nativeTokenSymbol}`}
                         />
                       </div>
-                      <div className="flex items-center gap-2 w-full md:w-auto">
+                      <div className="flex w-full items-center gap-2 md:w-auto">
                         <label
                           htmlFor="priceCeilingIncreasePercentage"
                           className="whitespace-nowrap"
@@ -174,44 +177,167 @@ export function AddStageDialog({
                         />
                         days.
                       </div>
-                      </div>
-                  <div>
+                    </div>
+                    <div>
+                      <FieldArray
+                        name="splits"
+                        render={(arrayHelpers) => (
+                          <div>
+                            {values.splits.map((_, index) => (
+                              <div
+                                key={index}
+                                className="text-md mt-4 flex items-center gap-2 text-zinc-600"
+                              >
+                                <label
+                                  className="whitespace-nowrap"
+                                  htmlFor={`splits.${index}.amount`}
+                                >
+                                  {index === 0 ? "Split" : "... and"}
+                                </label>
+                                <Field
+                                  id={`splits.${index}.percentage`}
+                                  name={`splits.${index}.percentage`}
+                                  type="number"
+                                  min="0"
+                                  max="100"
+                                  className="h-9"
+                                  width="w-28"
+                                  suffix="%"
+                                  required
+                                  placeholder="100"
+                                />
+                                <label
+                                  htmlFor={`splits.${index}.defaultBeneficiary`}
+                                >
+                                  to
+                                </label>
+                                <Field
+                                  id={`splits.${index}.defaultBeneficiary`}
+                                  name={`splits.${index}.defaultBeneficiary`}
+                                  className="h-9"
+                                  placeholder="0x"
+                                  required
+                                  defaultValue={
+                                    formikValues.stages[0]?.initialOperator ||
+                                    ""
+                                  }
+                                />
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => arrayHelpers.remove(index)}
+                                  className="h-9 px-0 sm:px-3"
+                                >
+                                  <TrashIcon className="h-4 w-4" />
+                                </Button>
+                              </div>
+                            ))}
+                            <Button
+                              type="button"
+                              onClick={() =>
+                                arrayHelpers.push({
+                                  percentage: "",
+                                  defaultBeneficiary: "",
+                                })
+                              }
+                              className="mt-3 h-7 border border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-900"
+                            >
+                              add split +
+                            </Button>
+                          </div>
+                        )}
+                      />
+                      {values.splits.length > 0 && (
+                        <div className="mt-4 border-l border-zinc-300 px-1 py-1 pl-2 text-sm font-medium text-zinc-500">
+                          Total split limit of{" "}
+                          {values.splits.reduce(
+                            (sum, split) =>
+                              sum + (Number(split.percentage) || 0),
+                            0,
+                          )}
+                          %, payer always receives{" "}
+                          {100 -
+                            values.splits.reduce(
+                              (sum, split) =>
+                                sum + (Number(split.percentage) || 0),
+                              0,
+                            )}
+                          % of issuance.
+                        </div>
+                      )}
+                      {values.splits.length == 0 && (
+                        <div className="mt-4 border-l border-zinc-300 px-1 py-1 pl-2 text-sm font-medium text-zinc-500">
+                          Without splits, the payer always receives 100% of
+                          issuance.
+                        </div>
+                      )}
+                      {values.splits.length > 0 && (
+                        <div className="text-md mt-4 flex items-center gap-2 whitespace-nowrap text-zinc-600">
+                          <label
+                            className="whitespace-nowrap"
+                            htmlFor="priceCeilingIncreasePercentage"
+                          >
+                            ... operated by
+                          </label>
+                          <Field
+                            id="initialOperator"
+                            name="initialOperator"
+                            className=""
+                            placeholder={
+                              stageIdx > 0
+                                ? formikValues.stages[0].initialOperator
+                                : "0x"
+                            }
+                            disabled={stageIdx > 0}
+                          />
+                          {stageIdx > 0 && (
+                            <Tooltip>
+                              <TooltipTrigger>[ ? ]</TooltipTrigger>
+                              <TooltipContent side="left">
+                                Set the operator in the first stage
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                        </div>
+                      )}
+                    </div>
                     <FieldArray
-                      name="splits"
+                      name="autoIssuance"
                       render={(arrayHelpers) => (
                         <div>
-                          {values.splits.map((_, index) => (
+                          <p className="text-md mt-5 text-zinc-500">
+                            Optionally, auto-issue {revnetTokenSymbol} when the
+                            stage starts.
+                          </p>
+                          {values.autoIssuance?.map((_, index) => (
                             <div
                               key={index}
-                              className="flex gap-2 items-center text-md text-zinc-600 mt-4"
+                              className="text-md mt-4 flex items-center gap-2 text-zinc-600"
                             >
-                              <label
-                                className="whitespace-nowrap"
-                                htmlFor={`splits.${index}.amount`}>
-                                {index === 0 ? "Split" : "... and"}
+                              <label htmlFor={`autoIssuance.${index}.amount`}>
+                                {index === 0 ? "Issue" : "...and"}
                               </label>
                               <Field
-                                id={`splits.${index}.percentage`}
-                                name={`splits.${index}.percentage`}
+                                id={`autoIssuance.${index}.amount`}
+                                name={`autoIssuance.${index}.amount`}
                                 type="number"
                                 min="0"
-                                max="100"
                                 className="h-9"
-                                width="w-28"
-                                suffix="%"
+                                suffix={`${revnetTokenSymbol}`}
                                 required
-                                placeholder="100"
+                                // width="w-72" // mobile padding issue
                               />
-                              <label htmlFor={`splits.${index}.defaultBeneficiary`}>
+                              <label
+                                htmlFor={`autoIssuance.${index}.beneficiary`}
+                              >
                                 to
                               </label>
                               <Field
-                                id={`splits.${index}.defaultBeneficiary`}
-                                name={`splits.${index}.defaultBeneficiary`}
+                                id={`autoIssuance.${index}.beneficiary`}
+                                name={`autoIssuance.${index}.beneficiary`}
                                 className="h-9"
                                 placeholder="0x"
                                 required
-                                defaultValue={formikValues.stages[0]?.initialOperator || ""}
                               />
                               <Button
                                 variant="ghost"
@@ -225,245 +351,177 @@ export function AddStageDialog({
                           ))}
                           <Button
                             type="button"
-                            onClick={() => arrayHelpers.push({ percentage: "", defaultBeneficiary: "" })}
-                            className="h-7 mt-3 bg-zinc-100 border border-zinc-200 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-900"
+                            onClick={() => {
+                              console.log(values);
+                              arrayHelpers.push({
+                                amount: "",
+                                beneficiary: "",
+                              });
+                            }}
+                            className="mt-3 h-7 border border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-900"
                           >
-                           add split +
+                            add auto issuance +
                           </Button>
+                          {values.autoIssuance.length > 0 && (
+                            <div className="mt-4 border-l border-zinc-300 px-1 py-1 pl-2 text-sm font-medium text-zinc-500">
+                              Total auto issuance of{" "}
+                              {commaNumber(
+                                values.autoIssuance?.reduce(
+                                  (sum, issuance) =>
+                                    sum + (Number(issuance.amount) || 0),
+                                  0,
+                                ),
+                              )}{" "}
+                              {revnetTokenSymbol}.
+                            </div>
+                          )}
                         </div>
                       )}
                     />
-                    {
-                      values.splits.length > 0  && <div className="text-sm font-medium text-zinc-500 mt-4 border-l border-zinc-300 pl-2 py-1 px-1">
-                        Total split limit of {values.splits.reduce((sum, split) => sum + (Number(split.percentage) || 0), 0)}%, payer always receives {100 - values.splits.reduce((sum, split) => sum + (Number(split.percentage) || 0), 0)}% of issuance.
+                    <NotesSection>
+                      <div className="text-md mt-4 italic text-zinc-600">
+                        <ul className="list-inside list-disc space-y-2">
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            Cutting issuance by 50% means to double the price –
+                            a halvening effect.
+                          </li>
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            If there's a market for {revnetTokenSymbol} /{" "}
+                            {nativeTokenSymbol} offering a better price, all{" "}
+                            {nativeTokenSymbol} paid in will be used to buyback
+                            instead of feeding the revnet. Uniswap is used as
+                            the market.
+                          </li>
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            Splits apply to both issuance and buybacks.
+                          </li>
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            <span>
+                              You can write and deploy a custom split hook that
+                              automatically receives and processes the split{" "}
+                              {revnetTokenSymbol}. See{" "}
+                              <a
+                                className="inline underline"
+                                target="_blank"
+                                href="https://docs.juicebox.money/v4/build/hooks/split-hook/"
+                              >
+                                {" "}
+                                the docs.
+                              </a>
+                            </span>
+                          </li>
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            If there are splits, the operator can change the
+                            distribution of the split limit to new destinations
+                            at any time.
+                          </li>
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            The operator can be a multisig, a DAO, an LLC, a
+                            core team, an airdrop stockpile, a staking rewards
+                            contract, or some other address.
+                          </li>
+                          <li className="flex">
+                            <span className="mr-2">•</span>
+                            The operator is set once and is not bound by stages.
+                            The operator can hand off this responsibility to
+                            another address at any time, or relinquish it
+                            altogether.
+                          </li>
+                        </ul>
                       </div>
-                    }
-                    {
-                      values.splits.length == 0 && <div className="text-sm font-medium text-zinc-500 mt-4 border-l border-zinc-300 pl-2 py-1 px-1">
-                        Without splits, the payer always receives 100% of issuance.
-                      </div>
-                    }
-                  {
-                    values.splits.length > 0 && (
-                  <div className="mt-4 flex gap-2 items-center text-md text-zinc-600 whitespace-nowrap">
-                    <label
-                    className="whitespace-nowrap"
-                    htmlFor="priceCeilingIncreasePercentage">
-                      ... operated by
-                    </label>
-                    <Field
-                      id="initialOperator"
-                      name="initialOperator"
-                      className=""
-                      placeholder={
-                        stageIdx > 0
-                          ? formikValues.stages[0].initialOperator
-                          : "0x"
-                      }
-                      disabled={stageIdx > 0}
-                    />
-                    {stageIdx > 0 && (
-                      <Tooltip>
-                        <TooltipTrigger>[ ? ]</TooltipTrigger>
-                        <TooltipContent side="left">
-                          Set the operator in the first stage
-                        </TooltipContent>
-                      </Tooltip>
-                      )}
-                    </div>
-                  )}
-                  </div>
-                  <FieldArray
-                    name="autoIssuance"
-                    render={(arrayHelpers) => (
-                      <div>
-                        <p className="text-md text-zinc-500 mt-5">
-                          Optionally, auto-issue {revnetTokenSymbol} when the stage starts.
-                        </p>
-                        {values.autoIssuance?.map((_, index) => (
-                          <div
-                            key={index}
-                            className="flex gap-2 items-center text-md text-zinc-600 mt-4"
-                          >
-                            <label htmlFor={`autoIssuance.${index}.amount`}>
-                              {index === 0 ? "Issue" : "...and"}
-                            </label>
-                            <Field
-                              id={`autoIssuance.${index}.amount`}
-                              name={`autoIssuance.${index}.amount`}
-                              type="number"
-                              min="0"
-                              className="h-9"
-                              suffix={`${revnetTokenSymbol}`}
-                              required
-                              // width="w-72" // mobile padding issue
-                            />
-                            <label
-                              htmlFor={`autoIssuance.${index}.beneficiary`}
-                            >
-                              to
-                            </label>
-                            <Field
-                              id={`autoIssuance.${index}.beneficiary`}
-                              name={`autoIssuance.${index}.beneficiary`}
-                              className="h-9"
-                              placeholder="0x"
-                              required
-                            />
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => arrayHelpers.remove(index)}
-                              className="h-9 px-0 sm:px-3"
-                            >
-                              <TrashIcon className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        ))}
-                        <Button
-                          type="button"
-                          onClick={() => {
-                            console.log(values);
-                            arrayHelpers.push({ amount: "", beneficiary: "" });
-                          }}
-                          className="h-7 mt-3 bg-zinc-100 border border-zinc-200 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-900"
-                        >
-                          add auto issuance +
-                        </Button>
-                        { values.autoIssuance.length > 0 && <div className="text-sm font-medium text-zinc-500 mt-4 border-l border-zinc-300 pl-2 py-1 px-1">
-                          Total auto issuance of {" "}
-                          {commaNumber(values.autoIssuance?.reduce((sum, issuance) => sum + (Number(issuance.amount) || 0), 0))}
-                          {" "}{revnetTokenSymbol}.
-                        </div>
-                        }
-                      </div>
-                    )}
-                  />
-                  <NotesSection>
-                    <div className="text-zinc-600 text-md mt-4 italic">
-                      <ul className="list-disc list-inside space-y-2">
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          Cutting issuance by 50% means to double the price – a
-                          halvening effect.
-                        </li>
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          If there's a market for {revnetTokenSymbol} /{" "}
-                          {nativeTokenSymbol} offering a better price, all{" "}
-                          {nativeTokenSymbol} paid in will be used to buyback
-                          instead of feeding the revnet. Uniswap is used as
-                          the market.
-                        </li>
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          Splits apply to both issuance and buybacks.
-                        </li>
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          <span>
-                            You can write and deploy a custom split hook that automatically receives and processes the split {revnetTokenSymbol}. See <a className="inline underline" target="_blank" href="https://docs.juicebox.money/v4/build/hooks/split-hook/"> the docs.</a>
-                          </span>
-                        </li>
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          If there are splits, the operator can change the distribution of the split
-                          limit to new destinations at any time.
-                        </li>
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          The operator can be a multisig, a DAO, an LLC, a core
-                          team, an airdrop stockpile, a staking rewards
-                          contract, or some other address.
-                        </li>
-                        <li className="flex">
-                          <span className="mr-2">•</span>
-                          The operator is set once and is not bound by stages.
-                          The operator can hand off this responsibility to
-                          another address at any time, or relinquish it
-                          altogether.
-                        </li>
-                      </ul>
-                    </div>
-                  </NotesSection>
+                    </NotesSection>
                   </div>
                 </div>
 
                 <div className="pb-10">
                   <div
                     id="priceFloorTaxIntensity-group"
-                    className="block text-md font-semibold leading-6"
+                    className="text-md block font-semibold leading-6"
                   >
                     2. Cash out tax
                   </div>
-                  <p className="text-md text-zinc-500 mt-3">
-                    The only way for anyone to access {revnetTokenSymbol} revenue is by cashing out or
-                    taking out a loan against their {revnetTokenSymbol}.
-                    A tax can be added that makes cashing
+                  <p className="text-md mt-3 text-zinc-500">
+                    The only way for anyone to access {revnetTokenSymbol}{" "}
+                    revenue is by cashing out or taking out a loan against their{" "}
+                    {revnetTokenSymbol}. A tax can be added that makes cashing
                     out and taking out loans more expensive, while rewarding{" "}
                     {revnetTokenSymbol} holders who stick around as others cash
                     out.
                   </p>
-                    <div className="space-y-2 mt-6">
-                      <div className="flex justify-between relative w-full">
-                        {steps.map((step) => (
+                  <div className="my-4 space-y-4">
+                    <div>
+                      <div className="relative mb-2 flex w-full justify-between">
+                        {steps.map((step, index) => (
                           <span
-                            key={Number(step) / 100}
-                            className={
-                              Number(step) === 0
-                                ? "text-sm pl-1"
-                                : Number(step) === 20
-                                ? "text-sm pl-4"
-                                : "text-sm pl-2"
-                            }
+                            key={step}
+                            className={`text-sm text-zinc-600 ${
+                              index === 0
+                                ? "ml-0"
+                                : index === steps.length - 1
+                                  ? "mr-0"
+                                  : ""
+                            }`}
                           >
-                            {Number(step) / 100}
+                            {step}%
                           </span>
                         ))}
                       </div>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="range"
-                          min={0}
-                          max={80}
-                          step={10}
-                          name="priceFloorTaxIntensity"
-                          value={cashOutTax}
-                          onChange={(e: any) => {
-                            const numValue = parseFloat(e.target.value);
-                            const closestHalfStep = Math.round(numValue * 20) / 20;
-                            setCashOutTax(closestHalfStep);
-                            values.priceFloorTaxIntensity = String(closestHalfStep);
-                          }}
-                          className="w-full h-2 bg-gray-200 appearance-none cursor-pointer accent-teal-500"
-                          aria-label="Exit tax percentage"
-                        />
+                      <input
+                        type="range"
+                        min={0}
+                        max={80}
+                        step={1}
+                        name="priceFloorTaxIntensity"
+                        value={cashOutTax}
+                        onChange={(e: any) => {
+                          const numValue = parseFloat(e.target.value);
+                          setCashOutTax(numValue);
+                          values.priceFloorTaxIntensity = String(numValue);
+                        }}
+                        className="h-2 w-full cursor-pointer appearance-none bg-gray-200 accent-teal-500"
+                        aria-label="Exit tax percentage"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {/* <span className="text-sm text-zinc-600">Cash out:</span> */}
+                      <div className="relative inline-flex items-center">
                         <Input
                           type="number"
                           min={0}
-                          max={0.8}
-                          step={0.01}
-                          value={(cashOutTax / 100).toString()}
+                          max={80}
+                          step={0.1}
+                          value={cashOutTax.toString()}
                           onChange={(e) => {
-                            const decimal = parseFloat(e.target.value);
-                            const bounded = isNaN(decimal)
+                            const percentage = parseFloat(e.target.value);
+                            const bounded = isNaN(percentage)
                               ? 0
-                              : Math.max(0, Math.min(0.8, decimal));
-                            const scaled = Math.round(bounded * 100 * 100) / 100;
-                            setCashOutTax(scaled);
-                            values.priceFloorTaxIntensity = String(scaled);
+                              : Math.max(0, Math.min(80, percentage));
+                            setCashOutTax(bounded);
+                            values.priceFloorTaxIntensity = String(bounded);
                           }}
-                          className="w-20 h-9"
-                          aria-label="Custom cash out tax"
+                          className="h-9 w-20 pr-7"
+                          aria-label="Custom cash out tax percentage"
                         />
+                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-sm text-zinc-500">
+                          %
+                        </span>
                       </div>
                     </div>
-                  <div className="text-sm font-medium text-zinc-500 mt-4 border-l border-zinc-300 pl-2 py-1 px-1">
-                    Cashing out 10% of {revnetTokenSymbol} gets {calculateYield(Number(cashOutTax))}% of the revnet's {nativeTokenSymbol}.
+                  </div>
+                  <div className="mt-4 border-l border-zinc-300 px-1 py-1 pl-2 text-sm font-medium text-zinc-500">
+                    Cashing out 10% of {revnetTokenSymbol} gets{" "}
+                    {calculateYield(Number(cashOutTax))}% of the revnet's{" "}
+                    {nativeTokenSymbol}.
                   </div>
                   <NotesSection>
-                    <div className="text-zinc-600 text-md mt-4 italic">
-                      <ul className="list-disc list-inside space-y-2">
+                    <div className="text-md mt-4 italic text-zinc-600">
+                      <ul className="list-inside list-disc space-y-2">
                         <li className="flex">
                           <span className="mr-2">•</span>
                           The higher the tax, the less that can be accessed by
@@ -474,7 +532,9 @@ export function AddStageDialog({
 
                         <li className="flex">
                           <span className="mr-2">•</span>
-                            Loans are an automated source of revenue for {revnetTokenSymbol}. By making loans more expensive, a higher cash out tax reduces potential loan revenue.
+                          Loans are an automated source of revenue for{" "}
+                          {revnetTokenSymbol}. By making loans more expensive, a
+                          higher cash out tax reduces potential loan revenue.
                         </li>
                         <li className="flex">
                           <span className="mr-2">•</span>
@@ -512,7 +572,7 @@ export function AddStageDialog({
                       width="w-32"
                     />
                     <NotesSection>
-                      <ul className="list-disc list-inside">
+                      <ul className="list-inside list-disc">
                         <li className="flex">
                           <span className="mr-2">•</span>
                           <div>

--- a/src/app/create/form/AddStageDialog.tsx
+++ b/src/app/create/form/AddStageDialog.tsx
@@ -19,6 +19,7 @@ import {
 import {
   defaultStageData } from "../constants";
 import { Field, FieldGroup } from "./Fields";
+import { Input } from "@/components/ui/input";
 import {
   Tooltip,
   TooltipContent,
@@ -403,31 +404,60 @@ export function AddStageDialog({
                     {revnetTokenSymbol} holders who stick around as others cash
                     out.
                   </p>
-                  <div className="space-y-2 mt-6">
-                    <div className="flex justify-between relative w-full">
-                      {steps.map((step) => (
-                        <span key={Number(step) / 100} className={ Number(step) === 0 ? "text-sm pl-1" : Number(step) === 20 ? "text-sm pl-4" : "text-sm pl-2"}>
-                          {Number(step) / 100}
-                        </span>
-                      ))}
+                    <div className="space-y-2 mt-6">
+                      <div className="flex justify-between relative w-full">
+                        {steps.map((step) => (
+                          <span
+                            key={Number(step) / 100}
+                            className={
+                              Number(step) === 0
+                                ? "text-sm pl-1"
+                                : Number(step) === 20
+                                ? "text-sm pl-4"
+                                : "text-sm pl-2"
+                            }
+                          >
+                            {Number(step) / 100}
+                          </span>
+                        ))}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="range"
+                          min={0}
+                          max={80}
+                          step={10}
+                          name="priceFloorTaxIntensity"
+                          value={cashOutTax}
+                          onChange={(e: any) => {
+                            const numValue = parseFloat(e.target.value);
+                            const closestHalfStep = Math.round(numValue * 20) / 20;
+                            setCashOutTax(closestHalfStep);
+                            values.priceFloorTaxIntensity = String(closestHalfStep);
+                          }}
+                          className="w-full h-2 bg-gray-200 appearance-none cursor-pointer accent-teal-500"
+                          aria-label="Exit tax percentage"
+                        />
+                        <Input
+                          type="number"
+                          min={0}
+                          max={0.8}
+                          step={0.01}
+                          value={(cashOutTax / 100).toString()}
+                          onChange={(e) => {
+                            const decimal = parseFloat(e.target.value);
+                            const bounded = isNaN(decimal)
+                              ? 0
+                              : Math.max(0, Math.min(0.8, decimal));
+                            const scaled = Math.round(bounded * 100 * 100) / 100;
+                            setCashOutTax(scaled);
+                            values.priceFloorTaxIntensity = String(scaled);
+                          }}
+                          className="w-20 h-9"
+                          aria-label="Custom cash out tax"
+                        />
+                      </div>
                     </div>
-                    <input
-                      type="range"
-                      min={0}
-                      max={80}
-                      step={10}
-                      name="priceFloorTaxIntensity"
-                      value={cashOutTax}
-                      onChange={(e: any) => {
-                        const numValue = parseFloat(e.target.value);
-                        const closestHalfStep = Math.round(numValue * 20) / 20;
-                        setCashOutTax(closestHalfStep);
-                        values.priceFloorTaxIntensity = String(closestHalfStep);
-                      }}
-                      className="w-full h-2 bg-gray-200 appearance-none cursor-pointer accent-teal-500"
-                      aria-label="Exit tax percentage"
-                    />
-                  </div>
                   <div className="text-sm font-medium text-zinc-500 mt-4 border-l border-zinc-300 pl-2 py-1 px-1">
                     Cashing out 10% of {revnetTokenSymbol} gets {calculateYield(Number(cashOutTax))}% of the revnet's {nativeTokenSymbol}.
                   </div>

--- a/src/app/create/form/AddStageDialog.tsx
+++ b/src/app/create/form/AddStageDialog.tsx
@@ -160,6 +160,7 @@ export function AddStageDialog({
                           autoFocus={true}
                           min="0"
                           max="100"
+                          step="0.1"
                           className="h-9"
                           suffix="%"
                           required

--- a/src/app/create/form/ChainSelect.tsx
+++ b/src/app/create/form/ChainSelect.tsx
@@ -36,12 +36,7 @@ const TESTNETS: JBChainId[] = [
   baseSepolia.id,
 ];
 
-const MAINNETS: JBChainId[] = [
-  mainnet.id,
-  optimism.id,
-  base.id,
-  arbitrum.id,
-];
+const MAINNETS: JBChainId[] = [mainnet.id, optimism.id, base.id, arbitrum.id];
 
 export function ChainSelect({
   disabled = false,
@@ -65,34 +60,36 @@ export function ChainSelect({
       "chainIds",
       checked
         ? [...values.chainIds, chainId]
-        : values.chainIds.filter((id) => id !== chainId)
+        : values.chainIds.filter((id) => id !== chainId),
     );
   };
 
   const revnetTokenSymbol =
     values.tokenSymbol?.length > 0 ? `$${values.tokenSymbol}` : "token";
 
+  console.log(values);
+
   return (
     <>
       <div className="md:col-span-1">
-        <h2 className="font-bold text-lg mb-2">3. Deploy</h2>
-        <p className="text-zinc-600 text-lg">
+        <h2 className="mb-2 text-lg font-bold">3. Deploy</h2>
+        <p className="text-lg text-zinc-600">
           Pick which chains your revnet will accept money on and issue{" "}
           {revnetTokenSymbol} from.
         </p>
-        <p className="text-zinc-600 text-lg mt-2">
+        <p className="mt-2 text-lg text-zinc-600">
           Holders of {revnetTokenSymbol} can cash out on any of the selected
           chains, and can move their {revnetTokenSymbol} between chains at any
           time.
         </p>
-        <p className="text-zinc-600 text-lg mt-2">
+        <p className="mt-2 text-lg text-zinc-600">
           The Operator you set in your revnet's terms will also be able to add
           new chains to the revnet later.
         </p>
       </div>
       <div className="md:col-span-2">
         <div className="flex flex-col gap-4">
-          <div className="text-left text-black-500 font-semibold">
+          <div className="text-black-500 text-left font-semibold">
             Choose your chains
           </div>
           <div className="max-w-56">
@@ -116,12 +113,12 @@ export function ChainSelect({
               </SelectContent>
             </Select>
           </div>
-          <div className="flex flex-wrap gap-6 mt-4">
+          <div className="mt-4 flex flex-wrap gap-6">
             {environment === "production" ? (
               <>
                 {Object.values(JB_CHAINS)
                   .filter(({ chain }) =>
-                    MAINNETS.includes(chain.id as JBChainId)
+                    MAINNETS.includes(chain.id as JBChainId),
                   )
                   .map(({ chain, name }) => (
                     <label key={chain.id} className="flex items-center gap-2">
@@ -132,12 +129,12 @@ export function ChainSelect({
                         disabled={disabled}
                         className="disabled:opacity-50"
                         checked={values.chainIds.includes(
-                          Number(chain.id) as JBChainId
+                          Number(chain.id) as JBChainId,
                         )}
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                           handleChainSelect(
                             chain.id as JBChainId,
-                            e.target.checked
+                            e.target.checked,
                           );
                         }}
                       />
@@ -149,7 +146,7 @@ export function ChainSelect({
               <>
                 {Object.values(JB_CHAINS)
                   .filter(({ chain }) =>
-                    TESTNETS.includes(chain.id as JBChainId)
+                    TESTNETS.includes(chain.id as JBChainId),
                   )
                   .map(({ chain, name }) => (
                     <label key={chain.id} className="flex items-center gap-2">
@@ -160,12 +157,12 @@ export function ChainSelect({
                         disabled={disabled}
                         className="disabled:opacity-50"
                         checked={values.chainIds.includes(
-                          Number(chain.id) as JBChainId
+                          Number(chain.id) as JBChainId,
                         )}
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                           handleChainSelect(
                             chain.id as JBChainId,
-                            e.target.checked
+                            e.target.checked,
                           );
                         }}
                       />
@@ -208,17 +205,17 @@ export function ChainSelect({
           />
           {relayrResponse && (
             <div className="flex flex-col items-start">
-              <div className="text-xs italic mt-2">
+              <div className="mt-2 text-xs italic">
                 Quote valid until{" "}
                 {format(
                   relayrResponse.payment_info[0].payment_deadline,
-                  "h:mm:ss aaa"
+                  "h:mm:ss aaa",
                 )}
                 .
                 <Button
                   variant="link"
                   size="sm"
-                  className="italic text-xs px-1"
+                  className="px-1 text-xs italic"
                   disabled={isLoading}
                   onClick={() => getRelayrTxQuote.reset()}
                 >


### PR DESCRIPTION
## Summary
- allow users to specify a custom cash out tax value when creating a revnet

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862a1f7edac8327981914881cee7552